### PR TITLE
fix(android): make call-in-progress notification non-dismissible

### DIFF
--- a/android/src/main/java/ar/com/anura/plugins/phonecallnotification/CallInProgressNotificationService.java
+++ b/android/src/main/java/ar/com/anura/plugins/phonecallnotification/CallInProgressNotificationService.java
@@ -114,7 +114,7 @@ public class CallInProgressNotificationService extends Service {
     Notification.Builder notificationBuilder = new Notification.Builder(this, CHANNEL_ID)
       .setContentTitle(settings.getChannelName())
       // Ongoing notifications cannot be dismissed by the user
-      .setOngoing(false)
+      .setOngoing(true)
       // Set the "ticker" text which is sent to accessibility services.
       .setTicker(settings.getChannelName())
       // To know if it is necessary to disturb the user with a notification despite having activated the "Do not interrupt" mode
@@ -125,7 +125,7 @@ public class CallInProgressNotificationService extends Service {
       .setUsesChronometer(true)
       // VISIBILITY_PUBLIC displays the full content of the notification
       .setVisibility(Notification.VISIBILITY_PUBLIC)
-      .setAutoCancel(true)
+      .setAutoCancel(false)
       .setContentIntent(getPendingIntent(CALL_IN_PROGRESS_TAP_ACTION))
       .setColor(Color.parseColor(settings.getColor()))
       // Set whether or not this notification should not bridge to other devices.


### PR DESCRIPTION
## Summary

The call-in-progress notification can currently be swiped away by the user, even though the call is still active. This is unexpected behavior — an active call notification should only be dismissible via the 'End Call' action button.

## Changes

In `CallInProgressNotificationService.java`:
- `setOngoing(false)` → `setOngoing(true)` — prevents swipe-to-dismiss
- `setAutoCancel(true)` → `setAutoCancel(false)` — prevents dismiss on tap

Note: the existing code comment on line 117 already says *'Ongoing notifications cannot be dismissed by the user'* but the flag was set to `false`.

## Testing

Tested on Android 14. The notification now stays pinned during an active call and can only be ended via the 'End Call' button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In-call notifications are now persistent and cannot be dismissed by user interaction, ensuring critical call information remains visible during active calls. Notifications will no longer auto-dismiss after user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->